### PR TITLE
Added enum declaration for LongPtr

### DIFF
--- a/server/src/antlr/vba.g4
+++ b/server/src/antlr/vba.g4
@@ -211,6 +211,7 @@ commonModuleDeclarationElement
     | privateTypeDeclaration
     | publicTypeDeclaration
     | privateEnumDeclaration
+    | enumLongptrDeclaration
     | publicEnumDeclaration
     | privateExternalProcedureDeclaration
     ;
@@ -315,7 +316,8 @@ reservedMemberName
 globalEnumDeclaration: GLOBAL wsc  enumDeclaration;
 publicEnumDeclaration: (PUBLIC wsc)? enumDeclaration;
 privateEnumDeclaration: PRIVATE wsc enumDeclaration;
-enumDeclaration: ENUM wsc untypedName endOfStatement+ enumMemberList endOfStatement+ END wsc ENUM ;
+enumDeclaration: ENUM wsc untypedName endOfStatement+ enumMemberList endOfStatement+ END wsc ENUM;
+enumLongptrDeclaration: PRIVATE wsc ENUM wsc LONGPTR endOfStatement+ enumMemberList endOfStatement+ END wsc ENUM;
 enumMemberList: enumElement (endOfStatement enumElement)*;
 enumElement
     : remStatement


### PR DESCRIPTION
Enums were broken when declaring `Private Enum LongPtr`. This is used as faux type when working with VBA6 so that types are consistent in code, e.g.

```vb
#If VBA7 Then
  Private Declare PtrSafe Function GetDesktopWindow Lib "user32" () As LongPtr
#Else
  Private Enum LongPtr
    [_]
  End Enum
  Private Declare Function GetDesktopWindow Lib "user32" () As LongPtr
#End If
```

Fixes #19 