### PR TITLE
Improve Rem support + tests for comments

### DIFF
--- a/client/src/syntaxes/vba.tmLanguage.yaml
+++ b/client/src/syntaxes/vba.tmLanguage.yaml
@@ -415,15 +415,15 @@ repository:
 
   comments:
     patterns:
-      - include: "#remarkComments"
       - include: "#blockComments"
       - include: "#apostropheComments"
+      - include: "#remarkComments"
     repository:
       blockComments:
         # The sub-pattern consumes the \n if preceded by line continuation.
         # Capturing it there prevents the end pattern being matched.
         name: comment.block.vba
-        begin: (?i)\s*'.*\s_\s*
+        begin: (?i)(\s*'|(?<=^|:)\s*Rem\b).*\s_\s*
         end: \n
         patterns:
           - include: "#lineContinuation"
@@ -432,7 +432,7 @@ repository:
         match: (?i)\s*'.*
       remarkComments:
         name: comment.line.remark.vba
-        match: (?i)(?<=^|:)\s*Rem\b.*
+        match: (?i)(?<=^\d*?|:)\s*Rem\b.*
 
   attribute:
     name: meta.attribute.vba

--- a/client/src/syntaxes/vba.tmLanguage.yaml
+++ b/client/src/syntaxes/vba.tmLanguage.yaml
@@ -423,7 +423,7 @@ repository:
         # The sub-pattern consumes the \n if preceded by line continuation.
         # Capturing it there prevents the end pattern being matched.
         name: comment.block.vba
-        begin: (?i)(\s*'|(?<=^|:)\s*Rem\b).*\s_\s*
+        begin: (?i)(\s*'|(?<=^\d*?|:)\s*Rem\b).*\s_\s*
         end: \n
         patterns:
           - include: "#lineContinuation"

--- a/test/textmate/unit/module/comments.vba
+++ b/test/textmate/unit/module/comments.vba
@@ -1,0 +1,63 @@
+'  SYNTAX TEST "source.vba" "comments"
+
+' This is a comment with without indentation
+' <-------------------------------------------- comment.line.apostrophe.vba
+
+    ' This is a comment with indentation
+'   ^^^^^^^^^^^^^^^^^^^ comment.line.apostrophe.vba
+
+10 ' Comment with line number
+' <-- constant.numeric.vba
+'  ^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.apostrophe.vba
+
+Label1: ' Comment with label
+'       ^^^^^^^^^^^^^^^^^^^^ comment.line.apostrophe.vba
+
+Dim x as Long 'Comment at the end of a line
+'             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.apostrophe.vba
+
+Dim x As Long: 'Comment with colon
+'              ^^^^^^^^^^^^^^^^^^^ comment.line.apostrophe.vba
+
+' This is the start of a comment block _
+' ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.vba
+
+' This is a comment _
+  continued on the next line
+' ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.vba
+
+' This is a comment _
+  continued on the next line _
+  and another line
+' ^^^^^^^^^^^^^^^^ comment.block.vba
+
+Rem This is a remark without indentation
+' <-------------------------------------- comment.line.remark.vba
+
+    Rem This is a remark with indentation
+'   ^^^^^^^^^^^^^^^^^^^^ comment.line.remark.vba
+
+10 Rem Comment with line number
+' <-- constant.numeric.vba
+'  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.remark.vba
+
+Label1: Rem Comment with label
+'       ^^^^^^^^^^^^^^^^^^^^^^ comment.line.remark.vba
+
+Dim x as Long Rem Comment at the end of a line
+'             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - comment.line.remark.vba
+
+Dim x As Long: Rem Comment with colon
+'              ^^^^^^^^^^^^^^^^^^^^^^ comment.line.remark.vba
+
+  Rem This is the start of a comment block _
+' ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.vba
+
+Rem This is a comment _
+  continued on the next line
+' ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.vba
+
+Rem This is a comment _
+  continued on the next line _
+  and another line
+' ^^^^^^^^^^^^^^^^ comment.block.vba


### PR DESCRIPTION
This PR allows Rem comments (aka. remarks) to support comment blocks as it is currently supported in the VBE.
Note that I had to change the order of the include statements to avoid `remarkComments` taking over.

I've also added support for the case where a line number preceeds the Rem comment.

Regarding the unit tests, I've used `'` as the comment token, but I can change it to `//` if needed.
Also note I'm using the negation pattern with ` - comment.line.remark.vba` for the line `Rem Comment at the end of a line` since it's not supported.