### PR TITLE
Deal with repeated If-Then on the same line + inline Ifs tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# EditorConfig is awesome: http://EditorConfig.org
+# Template from: https://github.com/DecimalTurn/VBA-on-GitHub
+
+# top-most EditorConfig file
+root = true
+
+# Properties for VBA, VB6 and twinBASIC file extensions
+[*.{bas,cls,frm,vba,doccls,ctl,dsr,twin,tbform}]
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+# Avoid line too long error (https://learn.microsoft.com/en-us/office/vba/language/reference/user-interface-help/line-too-long):
+max_line_length = 1023
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# The character set property isn't widely supported, but you can still add it. It just won't do anything if unsupported by your editor.
+# Reference: https://github.com/editorconfig/editorconfig/issues/209#issuecomment-445241830
+# Eg.:
+# charset = windows-1252
+# charset = us-ascii

--- a/client/src/syntaxes/vba.tmLanguage.yaml
+++ b/client/src/syntaxes/vba.tmLanguage.yaml
@@ -226,7 +226,7 @@ repository:
           
           inlineIfElse:
             name: meta.flow.inline-if-else.vba
-            match: (?i)\s*((?:else)?if)\s+(.*?)\s+(then)\s+(.*)\s+(else)\s+([^'\n]*)
+            match: (?i)\s*((?:else\s+)?if)\s+(.*?)\s+(then)\s+(.*)\s+(else)\s+([^'\n]*)
             captures:
               1:
                 name: keyword.control.flow.decision.vba
@@ -238,6 +238,8 @@ repository:
                 name: keyword.control.flow.decision.vba
               4:
                 patterns:
+                  - include: "#inlineIfElse"
+                  - include: "#inlineIf"
                   - include: "#expression"
                   - include: "#functionCall"
               5:

--- a/client/src/syntaxes/vba.tmLanguage.yaml
+++ b/client/src/syntaxes/vba.tmLanguage.yaml
@@ -259,6 +259,10 @@ repository:
                   - include: "#functionCall"
               3:
                 name: keyword.control.flow.decision.vba
+              4:
+                patterns:
+                  - include: "#inlineIfElse"
+                  - include: "#inlineIf"
 
           flowCall:
             name: keyword.control.flow.call.vba

--- a/contributing.md
+++ b/contributing.md
@@ -37,3 +37,7 @@ Note the grammar file for this project can be found at /server/src/antlr/vba.g4
   * Show ATN Graph for Rule
 
 The grammar call graph is interesting, but not particularly useful. Generating "valid" input generates garbage.
+
+### Run unit tests for TextMate grammar
+
+`npm run tmUnitTest`

--- a/test/textmate/unit/logicFlow.vba
+++ b/test/textmate/unit/logicFlow.vba
@@ -122,4 +122,15 @@ Public Sub Foo()
     End If
 '   ^^^^^^                                                  meta.flow.block-if-else.vba
 '   ^^^^^^                                                  keyword.control.flow.block-decision.vba
+
+
+'   Variable condition with repeated If
+    If condition Then If condition Then MsgBox "foo"
+'   ^^^^^^^^^^^^^^^^^                                       meta.flow.inline-if.vba
+'   ^^                                                      keyword.control.flow.decision.vba
+'                ^^^^                                       keyword.control.flow.decision.vba
+'                     ^^                                    keyword.control.flow.decision.vba
+'                                  ^^^^                     keyword.control.flow.decision.vba
+
+
 End Sub

--- a/test/textmate/unit/logicFlowBlock.vba
+++ b/test/textmate/unit/logicFlowBlock.vba
@@ -123,14 +123,4 @@ Public Sub Foo()
 '   ^^^^^^                                                  meta.flow.block-if-else.vba
 '   ^^^^^^                                                  keyword.control.flow.block-decision.vba
 
-
-'   Variable condition with repeated If
-    If condition Then If condition Then MsgBox "foo"
-'   ^^^^^^^^^^^^^^^^^                                       meta.flow.inline-if.vba
-'   ^^                                                      keyword.control.flow.decision.vba
-'                ^^^^                                       keyword.control.flow.decision.vba
-'                     ^^                                    keyword.control.flow.decision.vba
-'                                  ^^^^                     keyword.control.flow.decision.vba
-
-
 End Sub

--- a/test/textmate/unit/logicFlowInline.vba
+++ b/test/textmate/unit/logicFlowInline.vba
@@ -1,0 +1,144 @@
+'  SYNTAX TEST "source.vba" "logic flow inline"
+
+Attribute VB_Name = "Logic inline"
+
+Public Sub Foo()
+
+''''''''''''''''''''''''''''''''
+' 1. Inline Ifs (without nesting)
+''''''''''''''''''''''''''''''''
+
+''''''''''''''''
+' 1.1 Without Else
+''''''''''''''''
+
+'   Variable positive
+    If condition Then MsgBox "foo"
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      meta.flow.inline-if.vba
+'   ^^                                  keyword.control.flow.decision.vba
+'                ^^^^                   keyword.control.flow.decision.vba
+
+'   Variable negative
+    If Not condition Then MsgBox "foo"
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.flow.inline-if.vba
+'   ^^                                  keyword.control.flow.decision.vba
+'      ^^^                              keyword.operator.logical.vba
+'                    ^^^^               keyword.control.flow.decision.vba
+
+'   Function positive
+    If condition() Then MsgBox "foo"
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    meta.flow.inline-if.vba
+'   ^^                                  keyword.control.flow.decision.vba
+'      ^^^^^^^^^^^                      meta.function.call.vba
+'                  ^^^^                 keyword.control.flow.decision.vba
+
+'   Function negative
+    If Not condition() Then MsgBox "foo"
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    meta.flow.inline-if.vba
+'   ^^                                      keyword.control.flow.decision.vba
+'      ^^^                                  keyword.operator.logical.vba
+'          ^^^^^^^^^^^                      meta.function.call.vba
+'                      ^^^^                 keyword.control.flow.decision.vba
+
+'   Literal
+    If Not True Then MsgBox "foo"
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^       meta.flow.inline-if.vba
+'   ^^                                  keyword.control.flow.decision.vba
+'      ^^^                              keyword.operator.logical.vba
+'          ^^^^                         constant.language.boolean.vba
+'               ^^^^                    keyword.control.flow.decision.vba
+
+'   Expression
+    If Not condition = 5 Then MsgBox "foo"
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      meta.flow.inline-if.vba
+'   ^^                                          keyword.control.flow.decision.vba
+'      ^^^                                      keyword.operator.logical.vba
+'                    ^                          keyword.operator.comparison.vba
+'                      ^                        constant.numeric.vba
+'                        ^^^^                   keyword.control.flow.decision.vba
+
+''''''''''''''''
+' 1.2 With Else
+''''''''''''''''
+
+'   Variable positive
+    If condition Then MsgBox "foo" Else MsgBox "bar"
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.flow.inline-if-else.vba
+'   ^^ 	                                              keyword.control.flow.decision.vba
+'                ^^^^                                 keyword.control.flow.decision.vba
+'                                  ^^^^               keyword.control.flow.decision.vba
+
+'   Variable negative
+    If Not condition Then MsgBox "foo" Else MsgBox "bar"
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    meta.flow.inline-if-else.vba
+'   ^^                                                      keyword.control.flow.decision.vba
+'      ^^^                                                  keyword.operator.logical.vba
+'                    ^^^^                                   keyword.control.flow.decision.vba
+'                                      ^^^^                 keyword.control.flow.decision.vba
+
+'   Function positive
+    If condition() Then MsgBox "foo" Else MsgBox "bar"
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      meta.flow.inline-if-else.vba
+'   ^^                                                      keyword.control.flow.decision.vba
+'      ^^^^^^^^^^^                                          meta.function.call.vba
+'                  ^^^^                                     keyword.control.flow.decision.vba
+'                                    ^^^^                   keyword.control.flow.decision.vba
+
+'   Function negative
+    If Not condition() Then MsgBox "foo" Else MsgBox "bar"
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^      meta.flow.inline-if-else.vba
+'   ^^                                                          keyword.control.flow.decision.vba
+'      ^^^                                                      keyword.operator.logical.vba
+'          ^^^^^^^^^^^                                          meta.function.call.vba
+'                      ^^^^                                     keyword.control.flow.decision.vba
+'                                        ^^^^                   keyword.control.flow.decision.vba
+
+'   Literal
+    If Not True Then MsgBox "foo" Else MsgBox "bar"
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^         meta.flow.inline-if-else.vba
+'   ^^                                                      keyword.control.flow.decision.vba
+'      ^^^                                                  keyword.operator.logical.vba
+'          ^^^^                                             constant.language.boolean.vba
+'               ^^^^                                        keyword.control.flow.decision.vba
+'                                 ^^^^                      keyword.control.flow.decision.vba
+
+'   Expression
+    If Not condition = 5 Then MsgBox "foo" Else MsgBox "bar"
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^    meta.flow.inline-if-else.vba
+'   ^^                                                          keyword.control.flow.decision.vba
+'      ^^^                                                      keyword.operator.logical.vba
+'                    ^                                          keyword.operator.comparison.vba
+'                      ^                                        constant.numeric.vba
+'                        ^^^^                                   keyword.control.flow.decision.vba
+'                                          ^^^^                 keyword.control.flow.decision.vba
+
+''''''''''''''''''''''''''''''''
+' 2. Inline Ifs with nesting
+''''''''''''''''''''''''''''''''
+
+''''''''''''''''
+' 2.1 Without Else
+''''''''''''''''
+
+'   Variable condition with repeated If
+    If condition Then If condition Then MsgBox "foo"
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^        meta.flow.inline-if.vba
+'   ^^                                                      keyword.control.flow.decision.vba
+'                ^^^^                                       keyword.control.flow.decision.vba
+'                     ^^                                    keyword.control.flow.decision.vba
+'                                  ^^^^                     keyword.control.flow.decision.vba
+
+''''''''''''''''
+' 2.2 With Else
+''''''''''''''''
+
+'   Variable condition with repeated If and Else
+    If condition Then If condition Then MsgBox "foo" Else MsgBox "bar"
+'   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  meta.flow.inline-if-else.vba
+'   ^^ 	                                                                keyword.control.flow.decision.vba
+'                ^^^^                                                   keyword.control.flow.decision.vba
+'                     ^^                                                keyword.control.flow.decision.vba
+'                                  ^^^^                                 keyword.control.flow.decision.vba
+'                                                    ^^^^               keyword.control.flow.decision.vba
+
+End Sub


### PR DESCRIPTION
This PR fixes #35

It also provides tests for the inline if-statements based on the ones for block if-statements.

Regarding the `.EditorConfig` file, it's optional and I can remove it, but it helped me fix an issue where VS Code would insert tabs instead of 4 spaces in the test files (.vba) and that would mess up the alignment of the carets (`^`) used in the test 