### PR TITLE
Use "VS Code" spelling + link to marketplace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 	<img src="images/vba-lsp-icon.png" alt="drawing" width="128"/>
 </p>
 
-# VBA Pro Extension for VScode
+# VBA Pro Extension for VS Code
 
 Provides Visual Basic for Applications (VBA) language support in Visual Studio Code using a Language Server Protocol (LSP) compliant backend. We all know that VBA is a dinosaur from the '90s, but it doesn't have to feel like one.
 
@@ -38,7 +38,7 @@ A small but growing collection of highly useful code snippets. The idea is to ke
 
 ### Document Symbols
 
-Document Symbols allow you to view a structured outline of your code in the VSCode Outline view and breadcrumbs. These make it easy to understand and navigate files.
+Document Symbols allow you to view a structured outline of your code in the VS Code Outline view and breadcrumbs. These make it easy to understand and navigate files.
 
 ### Document Diagnostics
 
@@ -64,8 +64,8 @@ End Property
 
 ## Installation
 
-* Through the VSCode Marketplace,
-* VSCode command palette `ext install notisdataanalytics.vba-lsp`, or;
+* Through the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=NotisDataAnalytics.vba-lsp),
+* VS Code command palette `ext install notisdataanalytics.vba-lsp`, or;
 * Download the [visx](../../releases/latest).
 
 ## Contributing

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vba-lsp-client",
-	"description": "VSCode part of a language server",
+	"description": "VS Code part of a language server",
 	"author": "SSlinky",
 	"license": "MIT",
 	"version": "0.0.1",

--- a/contributing.md
+++ b/contributing.md
@@ -4,14 +4,14 @@
 ## Setup
 
 1. Fork this repo
-1. Install VSCode Extension [esBuild Problem Matchers](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers).
+1. Install VS Code Extension [esBuild Problem Matchers](https://marketplace.visualstudio.com/items?itemName=connor4312.esbuild-problem-matchers).
 2. Install [Java](https://www.oracle.com/au/java/technologies/downloads/) >= 11
 3. Install [NPM](https://github.com/coreybutler/nvm-windows)
 4. `npm install` to install dependencies.
 5. `npm run textMate` first time and every time grammar is changed.
 6. `npm run antlr` first time and every time grammar is changed.
 7. Create a `.\sample` directory as a default workspace for client debugging (or update .\\.vscode\\launch.json as preferred).
-7. (Optional) Install [ANTLR4 grammar syntax support](https://marketplace.visualstudio.com/items?itemName=mike-lischke.vscode-antlr4) VSCode extension.
+7. (Optional) Install [ANTLR4 grammar syntax support](https://marketplace.visualstudio.com/items?itemName=mike-lischke.vscode-antlr4) VS Code extension.
     Note: to debug a grammar, you'll first need to activate the extension by opening one of the *.g4 files.
 
 To contribute, you'll need to [create a pull request from a fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vba-lsp",
 	"type": "commonjs",
 	"displayName": "VBA Pro",
-	"description": "A VBA extension for VSCode with Language Server support",
+	"description": "A VBA extension for VS Code with Language Server support",
 	"icon": "images/vba-lsp-icon.png",
 	"author": "SSlinky",
 	"license": "MIT",


### PR DESCRIPTION
This PR simply changes uses of "VSCode" to "VS Code" which is the official spelling. 

![image](https://github.com/user-attachments/assets/67bba715-614b-4290-8948-c3492ce054bc)
[source](https://code.visualstudio.com/docs/getstarted/getting-started)

I've also added a link to the extension's page on the marketplace.