### PR TITLE
Restore Icon Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Provides Visual Basic for Applications (VBA) language support in Visual Studio C
 * Semantic highlighting
 * Folding ranges
 * Code Snippets
+* Icon theme
 * Document symbols
 * Document diagnostics
 * Document formatting<sup>1</sup>
@@ -40,6 +41,14 @@ Folding ranges help organise code, collapsing things out of the way when you don
 ### Code Snippets
 
 A small but growing collection of highly useful code snippets. The idea is to keep these to a "rememberable" level, but if there's something you use all the time and you think it's missing, I'd love to hear from you.
+
+### Icon Theme
+
+VS Code supports two ways of contributing icons.
+* Per language identifier. Limited to one icon for all file types.
+* Icon pack. Allows more flexibility, however, only one icon theme can be active at any time.
+
+This extension provides both methods. Users with no icon pack installed can use the icon pack provided by this extension to see a visual difference between classes, modules, and forms. Users who prefer to use an alternative icon pack can fall back to the language assigned icon.
 
 ### Document Symbols
 

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -40,9 +40,7 @@ export function activate(context: ExtensionContext) {
 	const clientOptions: LanguageClientOptions = {
 		// Register the server for plain text documents
 		documentSelector: [
-			{ scheme: 'file', language: 'vba-class' },
-			{ scheme: 'file', language: 'vba-module' },
-			{ scheme: 'file', language: 'vba-form' }
+			{ scheme: 'file', language: 'vba' }
 		],
 		synchronize: {
 			// Notify the server about file changes to '.clientrc files contained in the workspace
@@ -61,7 +59,7 @@ export function activate(context: ExtensionContext) {
 	// Add logging support for messages received from the server.
 	client.onNotification("window/logMessage", (params) => {
 		VscodeLogger.logMessage(params);
-	})
+	});
 
 	// Start the client. This will also launch the server
 	client.start();

--- a/icon-theme.json
+++ b/icon-theme.json
@@ -1,18 +1,34 @@
 {
+	"iconDefinitions": {
+		"_class": {
+			"iconPath": "icons/vba_90sGreen_dark.svg"
+		},
+		"_class_light": {
+			"iconPath": "icons/vba_90sGreen_light.svg"
+		},
+		"_module": {
+			"iconPath": "icons/vba_90sPurple_dark.svg"
+		},
+		"_module_light": {
+			"iconPath": "icons/vba_90sPurple_light.svg"
+		},
+		"_userform": {
+			"iconPath": "icons/vba_90sYellow_dark.svg"
+		},
+		"_userform_light": {
+			"iconPath": "icons/vba_90sPurple_light.svg"
+		}
+	},
 	"fileExtensions": {
 		"cls": "_class",
 		"bas": "_module",
 		"frm": "_userform"
 	},
-	"iconDefinitions": {
-		"_class": {
-			"iconPath": "icons/vba_blue.svg"
-		},
-		"_module": {
-			"iconPath": "icons/vba_orange.svg"
-		},
-		"_userform": {
-			"iconPath": "icons/vba_green.svg"
+	"light": {
+		"fileExtensions": {
+			"cls": "_class_light",
+			"bas": "_module_light",
+			"frm": "_userform_light"
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 		"Programming Languages",
 		"Snippets",
 		"Linters",
-		"Formatters"
+		"Formatters",
+		"Themes"
 	],
 	"keywords": [
 		"multi-root ready"
@@ -30,46 +31,27 @@
 	"contributes": {
 		"languages": [
 			{
-				"id": "vba-class",
+				"id": "vba",
 				"aliases": [
-					"VBA Class"
+					"VBA"
 				],
 				"extensions": [
-					".cls"
+					".cls",
+					".bas",
+					".frm"
 				],
 				"configuration": "./vba.language-configuration.json",
 				"icon": {
 					"dark": "icons/vba_90sGreen_dark.svg",
 					"light": "icons/vba_90sGreen_light.svg"
 				}
-			},
+			}
+		],
+		"iconThemes": [
 			{
-				"id": "vba-module",
-				"aliases": [
-					"VBA Module"
-				],
-				"extensions": [
-					".bas"
-				],
-				"configuration": "./vba.language-configuration.json",
-				"icon": {
-					"dark": "icons/vba_90sPurple_dark.svg",
-					"light": "icons/vba_90sPurple_light.svg"
-				}
-			},
-			{
-				"id": "vba-form",
-				"aliases": [
-					"VBA Form"
-				],
-				"extensions": [
-					".frm"
-				],
-				"configuration": "./vba.language-configuration.json",
-				"icon": {
-					"dark": "icons/vba_90sYellow_dark.svg",
-					"light": "icons/vba_90sYellow_light.svg"
-				}
+				"id": "vba-lsp",
+				"label": "VBA Icons",
+				"path": "icon-theme.json"
 			}
 		],
 		"configurationDefaults": {
@@ -148,32 +130,14 @@
 		},
 		"grammars": [
 			{
-				"language": "vba-class",
-				"scopeName": "source.vba",
-				"path": "./client/syntaxes/vba.tmLanguage.json"
-			},
-			{
-				"language": "vba-module",
-				"scopeName": "source.vba",
-				"path": "./client/syntaxes/vba.tmLanguage.json"
-			},
-			{
-				"language": "vba-form",
+				"language": "vba",
 				"scopeName": "source.vba",
 				"path": "./client/syntaxes/vba.tmLanguage.json"
 			}
 		],
 		"snippets": [
 			{
-				"language": "vba-class",
-				"path": "./snippets/vba.json"
-			},
-			{
-				"language": "vba-module",
-				"path": "./snippets/vba.json"
-			},
-			{
-				"language": "vba-form",
+				"language": "vba",
 				"path": "./snippets/vba.json"
 			}
 		]

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
 		"postinstall": "cd client && npm install && cd ../server && npm install && cd ..",
 		"textMate": "npx js-yaml client/syntaxes/vba.tmLanguage.yaml > client/syntaxes/vba.tmLanguage.json && npm run tmSnapTest",
 		"antlr": "npm run antlr4ngPre && npm run antlr4ng && npm run antlr4ngFmt && npm run build",
-		"antlr4ng": "antlr4ng -Dlanguage=TypeScript -visitor -Xlog ./server/src/antlr/vba.g4 -o ./server/src/antlr/out/",
+		"antlr4ng": "antlr4ng -Dlanguage=TypeScript -visitor ./server/src/antlr/vba.g4 -o ./server/src/antlr/out/",
 		"antlr4ngPre": "antlr4ng -Dlanguage=TypeScript -visitor ./server/src/antlr/vbapre.g4 -o ./server/src/antlr/out/",
 		"antlr4ngFmt": "antlr4ng -Dlanguage=TypeScript -visitor ./server/src/antlr/vbafmt.g4 -o ./server/src/antlr/out/",
 		"test": "npm run tmSnapTest && npm run tmUnitTest && npm run vsctest",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
 	"scripts": {
 		"vscode:prepublish": "npm run package",
 		"build": "npm run check-types && node esbuild.js",
+		"fullBuild": "npm run textMate && npm run antlr",
 		"build-test": "node esbuild.js --test",
 		"check-types": "tsc --noEmit",
 		"watch": "npm-run-all -p watch:*",


### PR DESCRIPTION
Setting language identifier based icons did allow for the extension icons to work with icon packs, however, doing so required changing the 'vba' language identifier to be 'vba-class', 'vba-module', and 'vba-form'. Doing so broke snippet extensions as the language was no longer identified the same.

Function > form so it's better for icons not to work than for snippets not to work.