### PR TITLE
Better Syntax Error Message

### DIFF
--- a/client/src/test/diagnostics.test.ts
+++ b/client/src/test/diagnostics.test.ts
@@ -91,6 +91,12 @@ suite('Should get diagnostics', () => {
 				range: toRange(28, 7, 32, 8),
 				severity: vscode.DiagnosticSeverity.Error,
 				source: 'ex'
+			},
+			{
+				message: 'Invalid syntax: InvalidSubCall(arg)',
+				range: toRange(43, 4, 43, 23),
+				severity: vscode.DiagnosticSeverity.Error,
+				source: 'ex'
 			}
 		]);
 	});
@@ -156,8 +162,8 @@ async function testDiagnostics(docUri: vscode.Uri, expectedDiagnostics: vscode.D
 
 	expectedDiagnostics.forEach((expectedDiagnostic, i) => {
 		const actualDiagnostic = actualDiagnostics[i];
-		assert.equal(actualDiagnostic.message, expectedDiagnostic.message, "Message");
-		assert.deepEqual(actualDiagnostic.range, expectedDiagnostic.range, "Range");
-		assert.equal(actualDiagnostic.severity, expectedDiagnostic.severity, "Severity");
+		assert.equal(actualDiagnostic.message, expectedDiagnostic.message, `Message: expected '${expectedDiagnostic.message}' got '${actualDiagnostic.message}'.`);
+		assert.deepEqual(actualDiagnostic.range, expectedDiagnostic.range, `Range: expected '${JSON.stringify(expectedDiagnostic.range)}' got '${JSON.stringify(actualDiagnostic.range)}'.`);
+		assert.equal(actualDiagnostic.severity, expectedDiagnostic.severity, `Severity: expected '${expectedDiagnostic.severity}' got '${actualDiagnostic.severity}'.`);
 	});
 }

--- a/server/src/capabilities/semanticTokens.ts
+++ b/server/src/capabilities/semanticTokens.ts
@@ -12,7 +12,7 @@ import {
 import { ParserRuleContext } from 'antlr4ng/dist/ParserRuleContext';
 
 // Project
-import { BaseContextSyntaxElement, HasSemanticTokenCapability } from '../project/elements/base';
+import { BaseRuleSyntaxElement, HasSemanticTokenCapability } from '../project/elements/base';
 
 const registeredTokenTypes = new Map<string, number>((Object.keys(SemanticTokenTypes) as (keyof typeof SemanticTokenTypes)[]).map((k, i) => ([k, i])));
 const registeredTokenModifiers = new Map<string, number>((Object.keys(SemanticTokenModifiers) as (keyof typeof SemanticTokenModifiers)[]).map((k, i) => ([k, 2 ** i])));
@@ -30,7 +30,7 @@ export function activateSemanticTokenProvider(result: InitializeResult) {
 
 
 type SemanticElementType = HasSemanticTokenCapability
-	& BaseContextSyntaxElement<ParserRuleContext>;
+	& BaseRuleSyntaxElement<ParserRuleContext>;
 
 export class SemanticToken {
 	line: uinteger;

--- a/server/src/project/document.ts
+++ b/server/src/project/document.ts
@@ -11,7 +11,7 @@ import { SyntaxParser } from './parser/vbaParser';
 import { FoldingRange } from '../capabilities/folding';
 import { SemanticTokensManager } from '../capabilities/semanticTokens';
 import {
-	BaseContextSyntaxElement,
+	BaseRuleSyntaxElement,
 	BaseSyntaxElement,
 	DeclarableElement,
 	HasDiagnosticCapability,
@@ -54,7 +54,7 @@ export abstract class BaseProjectDocument {
 	protected foldableElements: FoldingRange[] = [];
 	protected hasDiagnosticElements: HasDiagnosticCapability[] = [];
 	protected properties: Dictionary<string, PropertyDeclarationElement> = new Dictionary(() => new PropertyDeclarationElement());
-	protected redactedElements: BaseContextSyntaxElement<ParserRuleContext>[] = [];
+	protected redactedElements: BaseRuleSyntaxElement<ParserRuleContext>[] = [];
 	protected semanticTokens: SemanticTokensManager = new SemanticTokensManager();
 	protected symbolInformations: SymbolInformation[] = [];
 	protected unhandledNamedElements: [] = [];
@@ -255,7 +255,7 @@ export abstract class BaseProjectDocument {
 		return this;
 	};
 
-	registerSubtractElement = (element: BaseContextSyntaxElement<ParserRuleContext>) => {
+	registerSubtractElement = (element: BaseRuleSyntaxElement<ParserRuleContext>) => {
 		this.redactedElements.push(element);
 		return this;
 	};

--- a/server/src/project/elements/base.ts
+++ b/server/src/project/elements/base.ts
@@ -3,7 +3,7 @@ import { Position, Range } from 'vscode-languageserver';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
 // Antlr
-import { ParserRuleContext, TerminalNode } from 'antlr4ng';
+import { Parser, ParserRuleContext, TerminalNode } from 'antlr4ng';
 
 // Project
 import {
@@ -16,9 +16,9 @@ import {
 } from '../../capabilities/capabilities';
 
 
-export abstract class BaseSyntaxElement<T extends ParserRuleContext> {
+export abstract class BaseSyntaxElement {
 	// Base Properties
-	context?: Context<T>;
+	context?: Context<ParserRuleContext | TerminalNode>;
 	identifierCapability?: IdentifierCapability;
 
 	// Capabilities
@@ -28,10 +28,22 @@ export abstract class BaseSyntaxElement<T extends ParserRuleContext> {
 	symbolInformationCapability?: SymbolInformationCapability;
 	scopeItemCapability?: ScopeItemCapability;
 
-	constructor();
-	constructor(ctx: T, doc: TextDocument)
-	constructor(ctx?: T, doc?: TextDocument) {
-		if (!!ctx && !!doc) this.context = new Context(ctx, doc);
+	/**
+	 *
+	 */
+	constructor() {
+		let x: TerminalNode | ParserRuleContext;
+		
+	}
+}
+
+
+export abstract class BaseRuleSyntaxElement<T extends ParserRuleContext> extends BaseSyntaxElement {
+	context!: Context<T>;
+
+	constructor(ctx: T, doc: TextDocument) {
+		super();
+		this.context = new Context(ctx, doc);
 	}
 
 	/**
@@ -39,10 +51,10 @@ export abstract class BaseSyntaxElement<T extends ParserRuleContext> {
 	 * @returns True if the element is a child of the passed element.
 	 */
 	isChildOf(range: Range): boolean;
-	isChildOf(element: BaseSyntaxElement<T>): boolean;
-	isChildOf(elementOrRange: BaseSyntaxElement<T> | Range): boolean {
+	isChildOf(element: BaseRuleSyntaxElement<T>): boolean;
+	isChildOf(elementOrRange: BaseRuleSyntaxElement<T> | Range): boolean {
 		const a = this.context?.range;
-		const b = ((o: any): o is BaseSyntaxElement<T> => 'context' in o)(elementOrRange)
+		const b = ((o: any): o is BaseRuleSyntaxElement<T> => 'context' in o)(elementOrRange)
 			? elementOrRange.context?.range
 			: elementOrRange;
 
@@ -59,7 +71,7 @@ export abstract class BaseSyntaxElement<T extends ParserRuleContext> {
 	 * Compare two syntax elements for equality.
 	 * @returns True if the document, range, and text match.
 	 */
-	equals(element: BaseSyntaxElement<T>): boolean {
+	equals(element: BaseRuleSyntaxElement<T>): boolean {
 		const a = this.context;
 		const b = element.context;
 
@@ -71,16 +83,7 @@ export abstract class BaseSyntaxElement<T extends ParserRuleContext> {
 }
 
 
-export abstract class BaseContextSyntaxElement<T extends ParserRuleContext> extends BaseSyntaxElement<T> implements HasContext<T> {
-	context!: Context<T>;
-
-	constructor(ctx: T, doc: TextDocument) {
-		super(ctx, doc);
-	}
-}
-
-
-export abstract class BaseIdentifyableSyntaxElement<T extends ParserRuleContext> extends BaseContextSyntaxElement<T> implements IsIdentifiable {
+export abstract class BaseIdentifyableSyntaxElement<T extends ParserRuleContext> extends BaseRuleSyntaxElement<T> implements IsIdentifiable {
 	abstract identifierCapability: IdentifierCapability;
 
 	constructor(ctx: T, doc: TextDocument) {
@@ -155,4 +158,4 @@ export interface HasFoldingRangeCapability {
 // Compound Types
 // ---------------------------------------------------------
 
-export type DeclarableElement = BaseContextSyntaxElement<ParserRuleContext> & IsIdentifiable & HasDiagnosticCapability;
+export type DeclarableElement = BaseRuleSyntaxElement<ParserRuleContext> & IsIdentifiable & HasDiagnosticCapability;

--- a/server/src/project/elements/flow.ts
+++ b/server/src/project/elements/flow.ts
@@ -6,10 +6,10 @@ import { AnyOperatorContext, IfStatementContext, WhileStatementContext } from '.
 
 // Project
 import { DiagnosticCapability, FoldingRangeCapability } from '../../capabilities/capabilities';
-import { BaseContextSyntaxElement, HasDiagnosticCapability } from './base';
+import { BaseRuleSyntaxElement, HasDiagnosticCapability } from './base';
 import { MultipleOperatorsDiagnostic, WhileWendDeprecatedDiagnostic } from '../../capabilities/diagnostics';
 
-export class IfElseBlock extends BaseContextSyntaxElement<IfStatementContext> {
+export class IfElseBlock extends BaseRuleSyntaxElement<IfStatementContext> {
 	constructor(context: IfStatementContext, document: TextDocument) {
 		super(context, document);
 		this.foldingRangeCapability = new FoldingRangeCapability(this);
@@ -19,7 +19,7 @@ export class IfElseBlock extends BaseContextSyntaxElement<IfStatementContext> {
 }
 
 
-export class WhileLoopElement extends BaseContextSyntaxElement<WhileStatementContext> implements HasDiagnosticCapability {
+export class WhileLoopElement extends BaseRuleSyntaxElement<WhileStatementContext> implements HasDiagnosticCapability {
 	diagnosticCapability: DiagnosticCapability;
 
 	constructor(context: WhileStatementContext, document: TextDocument) {
@@ -35,7 +35,7 @@ export class WhileLoopElement extends BaseContextSyntaxElement<WhileStatementCon
 }
 
 
-export class DuplicateOperatorElement extends BaseContextSyntaxElement<AnyOperatorContext> implements HasDiagnosticCapability {
+export class DuplicateOperatorElement extends BaseRuleSyntaxElement<AnyOperatorContext> implements HasDiagnosticCapability {
 	diagnosticCapability: DiagnosticCapability;
 
 	constructor(context: AnyOperatorContext, document: TextDocument) {

--- a/server/src/project/elements/generic.ts
+++ b/server/src/project/elements/generic.ts
@@ -2,17 +2,19 @@
 import { TextDocument } from 'vscode-languageserver-textdocument';
 
 // Antlr
-import { ErrorNode, ParserRuleContext } from 'antlr4ng';
+import { ErrorNode, ParserRuleContext, TerminalNode } from 'antlr4ng';
 
 // Project
-import { BaseContextSyntaxElement, BaseSyntaxElement } from './base';
+import { BaseRuleSyntaxElement, BaseSyntaxElement, Context } from './base';
 import { DiagnosticCapability } from '../../capabilities/capabilities';
 import { ParserErrorDiagnostic } from '../../capabilities/diagnostics';
 
 
-export class ErrorRuleElement extends BaseContextSyntaxElement<ParserRuleContext> {
+export class ErrorRuleElement extends BaseSyntaxElement {
+	context: Context<TerminalNode>;
 	constructor(node: ErrorNode, doc: TextDocument) {
-		super(node.parent as ParserRuleContext, doc);
+		super();
+		this.context = new Context(node, doc);
 		this.diagnosticCapability = new DiagnosticCapability(this);
 		this.diagnosticCapability.diagnostics.push(
 			new ParserErrorDiagnostic(this.context.range, node.getText())

--- a/server/src/project/elements/module.ts
+++ b/server/src/project/elements/module.ts
@@ -16,7 +16,7 @@ import {
 } from '../../antlr/out/vbaParser';
 
 // Project
-import { BaseContextSyntaxElement, BaseIdentifyableSyntaxElement, HasDiagnosticCapability } from './base';
+import { BaseRuleSyntaxElement, BaseIdentifyableSyntaxElement, HasDiagnosticCapability } from './base';
 import { DiagnosticCapability, FoldingRangeCapability, IdentifierCapability, ItemType, ScopeItemCapability, SymbolInformationCapability } from '../../capabilities/capabilities';
 import { DuplicateAttributeDiagnostic, IgnoredAttributeDiagnostic, MissingAttributeDiagnostic, MissingOptionExplicitDiagnostic } from '../../capabilities/diagnostics';
 
@@ -185,7 +185,7 @@ export class ClassElement extends BaseModuleElement<ClassModuleContext> {
 }
 
 
-export class ModuleIgnoredAttributeElement extends BaseContextSyntaxElement<ParserRuleContext> implements HasDiagnosticCapability {
+export class ModuleIgnoredAttributeElement extends BaseRuleSyntaxElement<ParserRuleContext> implements HasDiagnosticCapability {
 	diagnosticCapability: DiagnosticCapability;
 
 	constructor(ctx: IgnoredClassAttrContext | IgnoredProceduralAttrContext, doc: TextDocument) {

--- a/server/src/project/elements/precompiled.ts
+++ b/server/src/project/elements/precompiled.ts
@@ -6,11 +6,11 @@ import { CompilerConditionalBlockContext, CompilerDefaultBlockContext, CompilerI
 
 // Project
 import { DiagnosticCapability, FoldingRangeCapability } from '../../capabilities/capabilities';
-import { BaseContextSyntaxElement } from '../elements/base';
+import { BaseRuleSyntaxElement } from '../elements/base';
 import { UnreachableCodeDiagnostic } from '../../capabilities/diagnostics';
 
 
-export class CompilerLogicalBlock extends BaseContextSyntaxElement<CompilerIfBlockContext> {
+export class CompilerLogicalBlock extends BaseRuleSyntaxElement<CompilerIfBlockContext> {
 	conditionalBlocks: CompilerConditionBlock[] = [];
 	inactiveBlocks: CompilerConditionBlock[] = [];
 
@@ -38,7 +38,7 @@ export class CompilerLogicalBlock extends BaseContextSyntaxElement<CompilerIfBlo
 }
 
 
-class CompilerConditionBlock extends BaseContextSyntaxElement<CompilerConditionalBlockContext | CompilerDefaultBlockContext> {
+class CompilerConditionBlock extends BaseRuleSyntaxElement<CompilerConditionalBlockContext | CompilerDefaultBlockContext> {
 	readonly documentSettings: { environment: { os: string, version: string } };
 
 	constructor(ctx: CompilerConditionalBlockContext | CompilerDefaultBlockContext, doc: TextDocument, env: { environment: { os: string, version: string } }) {

--- a/server/src/project/elements/procedure.ts
+++ b/server/src/project/elements/procedure.ts
@@ -15,14 +15,14 @@ import {
 } from '../../antlr/out/vbaParser';
 
 // Project
-import { BaseContextSyntaxElement, HasDiagnosticCapability, HasSymbolInformationCapability } from './base';
+import { BaseRuleSyntaxElement, HasDiagnosticCapability, HasSymbolInformationCapability } from './base';
 import { AssignmentType, DiagnosticCapability, FoldingRangeCapability, IdentifierCapability, ItemType, ScopeItemCapability, SymbolInformationCapability } from '../../capabilities/capabilities';
 
 interface HasProcedureScope {
 	procedureScope(): ProcedureScopeContext | null
 }
 
-abstract class BaseProcedureElement<T extends ParserRuleContext & HasProcedureScope> extends BaseContextSyntaxElement<T> implements HasDiagnosticCapability, HasSymbolInformationCapability {
+abstract class BaseProcedureElement<T extends ParserRuleContext & HasProcedureScope> extends BaseRuleSyntaxElement<T> implements HasDiagnosticCapability, HasSymbolInformationCapability {
 	diagnosticCapability: DiagnosticCapability;
 	foldingRangeCapability: FoldingRangeCapability;
 	symbolInformationCapability: SymbolInformationCapability;

--- a/server/src/project/elements/typing.ts
+++ b/server/src/project/elements/typing.ts
@@ -23,11 +23,11 @@ import {
 
 // Project
 import { ElementOutOfPlaceDiagnostic, LegacyFunctionalityDiagnostic } from '../../capabilities/diagnostics';
-import { BaseContextSyntaxElement, HasDiagnosticCapability, HasSemanticTokenCapability, HasSymbolInformationCapability } from './base';
+import { BaseRuleSyntaxElement, HasDiagnosticCapability, HasSemanticTokenCapability, HasSymbolInformationCapability } from './base';
 import { AssignmentType, DiagnosticCapability, IdentifierCapability, ItemType, ScopeItemCapability, SemanticTokenCapability, SymbolInformationCapability } from '../../capabilities/capabilities';
 
 
-abstract class BaseTypeDeclarationElement<T extends ParserRuleContext> extends BaseContextSyntaxElement<T> implements HasDiagnosticCapability, HasSymbolInformationCapability, HasSemanticTokenCapability {
+abstract class BaseTypeDeclarationElement<T extends ParserRuleContext> extends BaseRuleSyntaxElement<T> implements HasDiagnosticCapability, HasSymbolInformationCapability, HasSemanticTokenCapability {
 	diagnosticCapability: DiagnosticCapability;
 	abstract identifierCapability: IdentifierCapability;
 	symbolInformationCapability: SymbolInformationCapability;
@@ -75,7 +75,7 @@ export class EnumDeclarationElement extends BaseTypeDeclarationElement<EnumDecla
 	}
 }
 
-export class EnumMemberDeclarationElement extends BaseContextSyntaxElement<EnumMemberContext> {
+export class EnumMemberDeclarationElement extends BaseRuleSyntaxElement<EnumMemberContext> {
 	identifierCapability: IdentifierCapability;
 
 	constructor(ctx: EnumMemberContext, doc: TextDocument) {
@@ -112,7 +112,7 @@ export class TypeDeclarationElement extends BaseTypeDeclarationElement<UdtDeclar
 // 		 attached until the object is constructed.
 //		 Also note that an event _can only be public_. 
 
-export class VariableDeclarationStatementElement extends BaseContextSyntaxElement<VariableDeclarationContext> {
+export class VariableDeclarationStatementElement extends BaseRuleSyntaxElement<VariableDeclarationContext> {
 
 	get isPublic(): boolean {
 		const modifierCtx = this.context.rule.variableModifier();
@@ -133,7 +133,7 @@ export class VariableDeclarationStatementElement extends BaseContextSyntaxElemen
 	}
 }
 
-export class ConstDeclarationStatementElement extends BaseContextSyntaxElement<ConstDeclarationContext> {
+export class ConstDeclarationStatementElement extends BaseRuleSyntaxElement<ConstDeclarationContext> {
 
 	get isPublic(): boolean {
 		const modifierCtx = this.context.rule.variableModifier();
@@ -153,7 +153,7 @@ export class ConstDeclarationStatementElement extends BaseContextSyntaxElement<C
 }
 
 
-export class VariableDeclarationElement extends BaseContextSyntaxElement<VariableDclContext | WitheventsVariableDclContext | ConstItemContext> implements HasDiagnosticCapability, HasSymbolInformationCapability { //, HasSemanticTokenCapability {
+export class VariableDeclarationElement extends BaseRuleSyntaxElement<VariableDclContext | WitheventsVariableDclContext | ConstItemContext> implements HasDiagnosticCapability, HasSymbolInformationCapability { //, HasSemanticTokenCapability {
 	identifierCapability: IdentifierCapability;
 	diagnosticCapability: DiagnosticCapability;
 	symbolInformationCapability: SymbolInformationCapability;
@@ -224,7 +224,7 @@ export class VariableDeclarationElement extends BaseContextSyntaxElement<Variabl
 }
 
 // ToDo: Needs to handle ClassTypeNameContext
-class VariableTypeInformation extends BaseContextSyntaxElement<TypeSuffixContext | AsClauseContext> {
+class VariableTypeInformation extends BaseRuleSyntaxElement<TypeSuffixContext | AsClauseContext> {
 	get isObjectType(): boolean {
 		// Type hints are never an object.
 		const ctx = this.context.rule;
@@ -291,7 +291,7 @@ class VariableTypeInformation extends BaseContextSyntaxElement<TypeSuffixContext
 }
 
 
-export class TypeSuffixElement extends BaseContextSyntaxElement<TypeSuffixContext> implements HasDiagnosticCapability, HasSemanticTokenCapability {
+export class TypeSuffixElement extends BaseRuleSyntaxElement<TypeSuffixContext> implements HasDiagnosticCapability, HasSemanticTokenCapability {
 	diagnosticCapability: DiagnosticCapability;
 	semanticTokenCapability: SemanticTokenCapability;
 

--- a/server/src/project/elements/utils.ts
+++ b/server/src/project/elements/utils.ts
@@ -6,11 +6,11 @@ import { UnexpectedEndOfLineContext } from '../../antlr/out/vbaParser';
 
 // Project
 import { DiagnosticCapability } from '../../capabilities/capabilities';
-import { BaseContextSyntaxElement, HasDiagnosticCapability } from './base';
+import { BaseRuleSyntaxElement, HasDiagnosticCapability } from './base';
 import { UnexpectedLineEndingDiagnostic } from '../../capabilities/diagnostics';
 
 
-export class UnexpectedEndOfLineElement extends BaseContextSyntaxElement<UnexpectedEndOfLineContext> implements HasDiagnosticCapability {
+export class UnexpectedEndOfLineElement extends BaseRuleSyntaxElement<UnexpectedEndOfLineContext> implements HasDiagnosticCapability {
 	diagnosticCapability: DiagnosticCapability;
 
 	constructor(context: UnexpectedEndOfLineContext, document: TextDocument) {

--- a/server/src/project/parser/vbaAntlr.ts
+++ b/server/src/project/parser/vbaAntlr.ts
@@ -90,48 +90,47 @@ export class VbaFmtParser extends vbafmtParser {
 
 export class VbaErrorHandler extends DefaultErrorStrategy {
     override recover(recognizer: Parser, e: RecognitionException): void {
+        // Try base recovery for some reason.
+        super.recover(recognizer, e);
+
         // Consume the error token if look-ahead is not EOF.
         const inputStream = recognizer.inputStream;
         if (inputStream.LA(1) !== Token.EOF) {
+            const intervalSet = this.getErrorRecoverySet(recognizer);
+            console.log(`recover consuming ${recognizer.getCurrentToken()}`);
             inputStream.consume();
+            // this.consumeUntil(recognizer, intervalSet);
         }
         this.endErrorCondition(recognizer);
     }
 
     override recoverInline(recognizer: Parser): Token {
-        const stream = recognizer.inputStream;
-        const thisToken = recognizer.getCurrentToken();
-
-        // Recover using deletion strategy.
-        const nextToken = stream.LT(2);
-        const expectedTokens = recognizer.getExpectedTokens();
-        if (nextToken && expectedTokens.contains(nextToken.type)) {
-            recognizer.consume();
-            this.reportMatch(recognizer);
-            return thisToken;
+        // Attempt to recover using token deletion.
+        const matchedSymbol = this.singleTokenDeletion(recognizer);
+        if (matchedSymbol) {
+          recognizer.consume();
+          return matchedSymbol;
         }
-
-        // Failsafe to prevent circular insertions.
-        const MAXRECURSION = -20;
-        for (let i = -1; i >= MAXRECURSION; i--) {
-            if (i <= -20) {
-                throw new InputMismatchException(recognizer);
-            }
-            const wasInsertedToken = this.isTokenPositionMatch(thisToken, recognizer.inputStream.LT(i));
-            if (!wasInsertedToken) {
-                break;
-            }
+        // Attempt to recover using token insertion.
+        if (this.singleTokenInsertion(recognizer)) {
+          return this.getMissingSymbol(recognizer);
         }
 
         // When we don't know what could come next, invalidate the entire line.
+        const stream = recognizer.inputStream;
+        const expectedTokens = recognizer.getExpectedTokens();
         if (expectedTokens.minElement === -1) {
             const invalidTokens: Token[] = [];
             while (![vbaLexer.NEWLINE, vbaLexer.EOF].includes(stream.LA(1))) {
                 invalidTokens.push(stream.LT(1)!);
+                console.log(`inline consuming ${recognizer.getCurrentToken()}`);
                 recognizer.consume();
             }
             if (invalidTokens.length > 0) {
                 const missingToken = this.createErrorToken(recognizer, invalidTokens);
+                this.reportMatch(recognizer);
+                console.log(`inline consuming ${recognizer.getCurrentToken()}`);
+                recognizer.consume();
                 return missingToken;
             }
         }

--- a/test/fixtures/Diagnostics.bas
+++ b/test/fixtures/Diagnostics.bas
@@ -30,3 +30,15 @@ Public Enum UniqueNameEnumFoo
     Enum2
     Enum3
 End Enum
+
+Public Sub CallsBadSub()
+Attribute CallsBadSub.VB_Description = "docstring."
+'   docstring.
+'
+'   Args:
+'       param1:
+'
+'   Raises:
+'
+    InvalidSubCall(arg)
+End Sub


### PR DESCRIPTION
Syntax errors still cause parsing to fail, however now only the offending line is underlined with the diagnostic text indicating it is invalid syntax.